### PR TITLE
Update Laravel framework version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "aws/aws-sdk-php": "^3.294",
         "bref/bref": "^2.1",
         "guzzlehttp/guzzle": "^6.3|^7.0",
-        "laravel/framework": "^8.0|^9.0|^10.0"
+        "laravel/framework": "^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.2",


### PR DESCRIPTION
An update to the Laravel framework version requirement in the composer.json file has been made. This new version indicates the acceptance of Laravel version 11.0 in addition to the existing version options, enhancing the project's compatibility with the latest Laravel releases.